### PR TITLE
Wire release metadata

### DIFF
--- a/.claude/skills/update-template.md
+++ b/.claude/skills/update-template.md
@@ -1,0 +1,276 @@
+---
+name: update-template
+description: Update this ingest repo to the latest copier template version, resolving known conflicts
+version: 1.0.0
+triggers:
+  - "update template"
+  - "copier update"
+  - "update to latest template"
+---
+
+# Update to Latest Template
+
+Update this ingest repo to the latest koza-ingest-template version using copier, with deterministic conflict resolution.
+
+**Use when:** The template has been updated (new CI patterns, justfile improvements, dependency changes) and you want to pull those changes into this repo.
+
+**Do NOT use when:**
+- This repo has no `.copier-answers.yml` (use the `migrate-standalone-ingest` skill first)
+- You want to create a new ingest (use the `create-koza-ingest` skill)
+
+---
+
+## Phase 1: Pre-flight
+
+### 1.1 Verify copier-managed repo
+
+Check for `.copier-answers.yml` at repo root. If missing, stop and tell the user this repo needs migration first.
+
+### 1.2 Record current state
+
+Capture these values before making any changes:
+
+```bash
+git branch --show-current        # Current branch
+git status --porcelain            # Dirty files
+grep '_commit:' .copier-answers.yml  # Current template commit
+```
+
+### 1.3 Capture local justfile
+
+**Read the entire justfile and save these values in memory** — you will need them after copier update:
+
+1. **TRANSFORMS variable**: The value after `TRANSFORMS :=` (e.g., `"gene disease phenotype"`)
+2. **`download:` recipe**: The full recipe body (e.g., `uv run downloader download.yaml`)
+3. **`run:` recipe**: The full dependency chain (e.g., `run: download postdownload transform-all postprocess`)
+4. **`transform-all:` dependencies**: What it depends on (e.g., `transform-all: download` or `transform-all: preprocess`)
+5. **Custom recipes**: Any of these if they exist — save the full recipe including body:
+   - `preprocess:`
+   - `postprocess:`
+   - `postdownload:`
+   - Any other non-standard recipes
+
+### 1.4 Report and confirm
+
+Tell the user:
+```
+Current branch: <branch>
+Current template commit: <commit>
+Dirty files: <list or none>
+Custom justfile recipes: <list>
+```
+
+---
+
+## Phase 2: Stash if Needed
+
+If `git status` shows uncommitted tracked changes:
+
+```bash
+git stash push -m "pre-template-update stash"
+```
+
+Record that a stash was created. Untracked files are fine — they won't interfere with copier.
+
+---
+
+## Phase 3: Run Copier Update
+
+```bash
+copier update --trust --defaults
+```
+
+After running, check if the template commit changed:
+
+```bash
+grep '_commit:' .copier-answers.yml
+```
+
+If the commit is the same as before, the repo is already up to date. Skip to Phase 7 (restore stash if needed).
+
+---
+
+## Phase 4: Resolve Conflicts
+
+### 4.1 Check for conflict markers
+
+```bash
+grep -rn "^<<<<<<<\|^=======\|^>>>>>>>" --include="*.yaml" --include="*.yml" --include="justfile" --include="*.toml" .
+```
+
+Even if no conflict markers are found, still verify the justfile and workflows (copier may have cleanly overwritten local customizations).
+
+### 4.2 Resolve justfile
+
+**Strategy: Local-first rebuild.** The justfile has repo-specific content (TRANSFORMS, download command, pipeline dependencies) that must be preserved.
+
+1. **Check for conflict markers** in justfile
+2. If conflicts exist, resolve each hunk:
+   - Hunks in `download:` recipe → **keep "before updating"** (local version)
+   - Hunks in `run:` recipe → **keep "before updating"** (local version)
+   - Hunks in custom recipes (preprocess/postdownload/etc.) → **keep "before updating"**
+   - Hunks in standard recipes (install/test/lint/format) → **keep "after updating"** (template version)
+
+   To keep "before updating": `sed -i '' '/^=======$/,/^>>>>>>> after updating$/d; /^<<<<<<< before updating$/d' justfile`
+   To keep "after updating": `sed -i '' '/^<<<<<<< before updating$/,/^=======$/d; /^>>>>>>> after updating$/d' justfile`
+
+3. **Verify TRANSFORMS** is not empty (unless it was empty before). If copier overwrote it with `""`, restore from Phase 1 capture.
+
+4. **Verify download recipe** matches Phase 1 capture. If copier replaced it with `uv run downloader download.yaml`, restore the local version.
+
+5. **Verify run recipe** dependencies match Phase 1 capture.
+
+6. **Verify custom recipes** (preprocess, postprocess, postdownload) still exist if they did before. Restore from Phase 1 capture if missing.
+
+7. **Remove duplicate recipes**: Check for duplicate `run:` (or any other) recipe definitions:
+   ```bash
+   grep -c '^run:' justfile
+   ```
+   If count > 1, the template added a duplicate. Remove the **second** occurrence (the template-added one, typically `run: transform-all test` with comment "Run full pipeline: install, download, transform, test"). Remove the comment, group annotation, and recipe definition (3 lines).
+
+### 4.3 Resolve workflow files
+
+**test.yaml** — Take the template version (standardized CI with `just run`):
+
+If conflict markers exist:
+```bash
+sed -i '' '/^<<<<<<< before updating$/,/^=======$/d; /^>>>>>>> after updating$/d' .github/workflows/test.yaml
+```
+
+**release.yaml** — Conditional:
+- If the local release.yaml has `schedule:`, `workflow_dispatch:`, custom `env:`, or `softprops/action-gh-release` with a custom body → **keep local** (it has repo-specific release logic)
+- If it closely matches the template (simple trigger, no custom body) → **take template**
+
+For keeping local:
+```bash
+sed -i '' '/^=======$/,/^>>>>>>> after updating$/d; /^<<<<<<< before updating$/d' .github/workflows/release.yaml
+```
+
+For taking template:
+```bash
+sed -i '' '/^<<<<<<< before updating$/,/^=======$/d; /^>>>>>>> after updating$/d' .github/workflows/release.yaml
+```
+
+### 4.4 Resolve other files
+
+- **pyproject.toml**: If conflicts, take template version. Then verify custom dependencies (e.g., `kghub-downloader`, `duckdb`, `cyvcf2`) are still listed. Restore any that were lost.
+- **.copier-answers.yml**: Always take the copier result (no conflicts expected).
+- **.gitignore**: Take template version (additive changes are safe).
+
+---
+
+## Phase 5: Fix Unrendered Jinja Tags
+
+Copier sometimes fails to render Jinja tags in workflow files. Check and fix:
+
+```bash
+grep -rn '{% raw %}\|{% endraw %}' .github/workflows/
+```
+
+If found, replace patterns like:
+```
+{% raw %}${{ matrix.python-version }}{% endraw %}
+```
+with:
+```
+${{ matrix.python-version }}
+```
+
+Use sed or manual edit to fix each occurrence.
+
+---
+
+## Phase 6: Verification
+
+Run these checks before committing:
+
+```bash
+# No conflict markers remain
+grep -rn "^<<<<<<<\|^=======\|^>>>>>>>" . --include="*.yaml" --include="*.yml" --include="justfile" --include="*.toml"
+
+# No unrendered Jinja tags
+grep -rn '{% raw %}\|{% endraw %}' .github/workflows/
+
+# Justfile parses correctly
+just --list
+
+# .copier-answers.yml has new commit
+grep '_commit:' .copier-answers.yml
+```
+
+Also verify by inspection:
+- TRANSFORMS variable is populated correctly
+- `download:` recipe has the correct command for this repo
+- `run:` recipe has the correct dependency chain
+- Custom recipes (preprocess, postprocess, etc.) are present if they should be
+
+---
+
+## Phase 7: Commit and Push
+
+**Always ask the user before committing.**
+
+List the changed files:
+```bash
+git status
+```
+
+Stage specific files (never `git add .`):
+```bash
+git add .copier-answers.yml justfile .github/workflows/test.yaml .github/workflows/release.yaml
+# Add any other changed files as appropriate
+```
+
+Commit:
+```bash
+git commit -m "chore: update to latest ingest template"
+```
+
+Push to current branch:
+```bash
+git push origin $(git branch --show-current)
+```
+
+If a stash was created in Phase 2:
+```bash
+git stash pop
+```
+
+If stash pop has conflicts, warn the user and help resolve them.
+
+---
+
+## Conflict Resolution Quick Reference
+
+| File/Section | Keep Local | Take Template | Notes |
+|-------------|-----------|---------------|-------|
+| justfile `TRANSFORMS` | Yes | | Template has empty string |
+| justfile `download:` | Yes | | Custom download commands per repo |
+| justfile `run:` | Yes | | Custom pipeline dependency chains |
+| justfile `preprocess:/postprocess:/postdownload:` | Yes | | Pipeline-specific custom recipes |
+| justfile `transform-all:` dependencies | Yes | | May depend on preprocess instead of download |
+| justfile `transform-all:` body | | Yes | Standardized iteration loop |
+| justfile `install:/test:/lint:/format:/clean:` | | Yes | Keep standardized |
+| justfile `setup:/_git-init/_git-add` | | Yes | Only used at project init |
+| `.github/workflows/test.yaml` | | Yes | Standardized CI |
+| `.github/workflows/release.yaml` (custom) | Yes | | Repo-specific release workflows |
+| `.github/workflows/release.yaml` (simple) | | Yes | Matches template pattern |
+| `pyproject.toml` | | Yes* | *Restore custom dependencies |
+| `.copier-answers.yml` | | Yes | Always from copier |
+| Duplicate `run:` recipe | Remove 2nd | | Copier merge artifact |
+
+---
+
+## Troubleshooting
+
+### "Updating is only supported in git-tracked templates"
+The `_src_path` in `.copier-answers.yml` points to a non-git source (e.g., old cookiecutter). This repo needs full migration first — use the `migrate-standalone-ingest` skill.
+
+### copier update prompts for input
+Use `--defaults` flag to skip prompts. If copier still prompts, check that `.copier-answers.yml` has all required fields.
+
+### Tests fail after update
+Common causes:
+- **Koza 2.x validation errors** (`Unexpected keyword argument` for reader/writer `name`): The transform YAML configs need migration to Koza 2.x format (remove `name` fields from reader/writer sections).
+- **Missing `dev` dependency group**: The `pyproject.toml` needs a `[dependency-groups]` section.
+- **Download failures in CI**: The `just run` recipe tries the full pipeline including download. If the data source requires secrets or authentication, configure them in the GitHub repo's secrets settings.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: adada77
+_commit: b7f2804
 _src_path: gh:monarch-initiative/koza-ingest-template
 copyright_year: '2026'
 email: kevin@tislab.org

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,5 +27,5 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
-      - name: Run pipeline
-        run: just run
+      - name: Run tests
+        run: just test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,11 @@ This is a Koza ingest repository for transforming MAxO annotation data into Biol
 - `download.yaml` - Configuration for downloading MAxO annotation data
 - `src/` - Transform code and configuration
   - `transform.py` / `transform.yaml` - Main transform for MAxO annotations
+  - `versions.py` - Per-ingest upstream version fetcher (consumed by `just metadata`)
+- `scripts/write_metadata.py` - Emits `output/release-metadata.yaml` from `versions.py`
 - `tests/` - Unit tests for transforms
 - `output/` - Generated nodes and edges (gitignored)
+  - `release-metadata.yaml` - Per-build manifest of upstream sources, versions, artifacts (kozahub-metadata-schema)
 - `data/` - Downloaded source data (gitignored)
 
 ## Key Commands
@@ -16,8 +19,23 @@ This is a Koza ingest repository for transforming MAxO annotation data into Biol
 - `just run` - Full pipeline (download -> transform)
 - `just download` - Download MAxO annotation data
 - `just transform-all` - Run all transforms
+- `just transform <name>` - Run specific transform
+- `just metadata` - Emit `output/release-metadata.yaml`
 - `just test` - Run tests
 
 ## Data Source
 
 MAxO (Medical Action Ontology) annotations linking medical actions to diseases and phenotypes.
+
+## Release Metadata
+
+Every kozahub ingest emits an `output/release-metadata.yaml` describing the upstream sources, their versions, the artifacts produced, and the versions of build-time tools. This file is the contract monarch-ingest reads to assemble the merged knowledge graph's release receipt.
+
+`src/versions.py` is the only per-ingest piece — it implements `get_source_versions()` returning a list of SourceVersion dicts. The `kozahub_metadata_schema` package provides reusable fetchers for the common patterns (HTTP Last-Modified, GitHub releases, URL-path regex, file-header parsing). The boilerplate (transform-content hashing, tool versions, build_version composition, yaml emission) is handled by `scripts/write_metadata.py`.
+
+The `kozahub-metadata-schema` repo is expected as a sibling checkout (path-dep). Switch to a git or PyPI dep once published.
+
+## Skills
+
+- `.claude/skills/create-koza-ingest.md` - Create new koza ingests
+- `.claude/skills/update-template.md` - Update to latest template version

--- a/justfile
+++ b/justfile
@@ -19,9 +19,9 @@ install:
 
 # ============== Ingest Pipeline ==============
 
-# Full pipeline: download -> transform -> postprocess
+# Full pipeline: download -> transform -> postprocess -> metadata
 [group('ingest')]
-run: download transform-all postprocess
+run: download transform-all postprocess metadata
     @echo "Done!"
 
 # Download source data
@@ -45,10 +45,6 @@ transform-all: download
 [group('ingest')]
 metadata:
     uv run python scripts/write_metadata.py
-
-# Run full pipeline: install, download, transform, metadata, test
-[group('ingest')]
-run: test transform-all metadata
 
 # Run specific transform
 [group('ingest')]

--- a/justfile
+++ b/justfile
@@ -41,6 +41,14 @@ transform-all: download
         fi
     done
 
+# Emit output/release-metadata.yaml describing this build's upstream sources and artifacts
+[group('ingest')]
+metadata:
+    uv run python scripts/write_metadata.py
+
+# Run full pipeline: install, download, transform, metadata, test
+[group('ingest')]
+run: test transform-all metadata
 
 # Run specific transform
 [group('ingest')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-# Path-dep on the kozahub metadata schema. Assumes the schema repo is checked
-# out as a sibling directory. Switch to `git = ...` or PyPI once published.
-kozahub-metadata-schema = { path = "../kozahub-metadata-schema", editable = true }
+kozahub-metadata-schema = { git = "https://github.com/monarch-initiative/kozahub-metadata-schema", rev = "main" }
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,14 @@ dependencies = [
   "biolink-model>=4.0.0",
   "duckdb>=0.10.2",
   "kghub-downloader>=0.4.0",
+  "kozahub-metadata-schema",
+  "requests>=2.28.0",
 ]
+
+[tool.uv.sources]
+# Path-dep on the kozahub metadata schema. Assumes the schema repo is checked
+# out as a sibling directory. Switch to `git = ...` or PyPI once published.
+kozahub-metadata-schema = { path = "../kozahub-metadata-schema", editable = true }
 
 [dependency-groups]
 dev = [

--- a/scripts/write_metadata.py
+++ b/scripts/write_metadata.py
@@ -1,0 +1,44 @@
+"""Emit output/release-metadata.yaml for maxo-annotation-ingest.
+
+Standard boilerplate — content is in src/versions.py and the schema package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+INGEST_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(INGEST_DIR / "src"))
+
+from versions import get_source_versions  # noqa: E402
+from kozahub_metadata_schema.writer import write_metadata  # noqa: E402
+
+
+if __name__ == "__main__":
+    src = INGEST_DIR / "src"
+    transform_paths = list(src.rglob("*.py")) + list(src.rglob("*.yaml"))
+
+    output_dir = INGEST_DIR / "output"
+    # Default to globbing every TSV / NT file in output/ as artifacts.
+    # Override the artifacts list explicitly if your ingest produces a fixed set.
+    artifacts = sorted(
+        p.name
+        for p in output_dir.glob("*")
+        if p.is_file() and p.suffix in {".tsv", ".gz", ".jsonl", ".nt"}
+    )
+
+    metadata = write_metadata(
+        ingest_name="maxo-annotation-ingest",
+        source_versions=get_source_versions(),
+        transform_paths=transform_paths,
+        artifacts=artifacts,
+        output_dir=output_dir,
+    )
+    print(f"Wrote {output_dir / 'release-metadata.yaml'}")
+    print(f"  build_version: {metadata['build_version']}")
+    for s in metadata["sources"]:
+        print(
+            f"  source {s['id']}: version={s['version']} via {s['version_method']} "
+            f"({len(s.get('urls') or [])} url(s))"
+        )

--- a/src/versions.py
+++ b/src/versions.py
@@ -1,0 +1,37 @@
+"""Upstream source version fetcher for maxo-annotation-ingest.
+
+MAxO annotations are tracked from a github master branch (no formal
+releases for the annotations file), so the version is the latest
+commit SHA on the maxo-annotations repo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from kozahub_metadata_schema import (
+    now_iso,
+    urls_from_download_yaml,
+    version_from_github_branch,
+)
+
+
+INGEST_DIR = Path(__file__).resolve().parents[1]
+DOWNLOAD_YAML = INGEST_DIR / "download.yaml"
+
+
+def get_source_versions() -> list[dict[str, Any]]:
+    ver, method = version_from_github_branch(
+        "monarch-initiative/maxo-annotations", branch="master"
+    )
+    return [
+        {
+            "id": "infores:maxo-annotations",
+            "name": "MAxO (Medical Action Ontology) Annotations",
+            "urls": urls_from_download_yaml(DOWNLOAD_YAML),
+            "version": ver,
+            "version_method": method,
+            "retrieved_at": now_iso(),
+        }
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -858,7 +858,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/65/5b235b40581ad75ab97dcd8b4218022ae8e3ab77c13c919f1a1dfe9171fd/greenlet-3.3.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:04bee4775f40ecefcdaa9d115ab44736cd4b9c5fba733575bfe9379419582e13", size = 273723, upload-time = "2026-01-23T15:30:37.521Z" },
     { url = "https://files.pythonhosted.org/packages/ce/ad/eb4729b85cba2d29499e0a04ca6fbdd8f540afd7be142fd571eea43d712f/greenlet-3.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e1457f4fed12a50e427988a07f0f9df53cf0ee8da23fab16e6732c2ec909d4", size = 574874, upload-time = "2026-01-23T16:00:54.551Z" },
     { url = "https://files.pythonhosted.org/packages/87/32/57cad7fe4c8b82fdaa098c89498ef85ad92dfbb09d5eb713adedfc2ae1f5/greenlet-3.3.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:070472cd156f0656f86f92e954591644e158fd65aa415ffbe2d44ca77656a8f5", size = 586309, upload-time = "2026-01-23T16:05:25.18Z" },
-    { url = "https://files.pythonhosted.org/packages/66/66/f041005cb87055e62b0d68680e88ec1a57f4688523d5e2fb305841bc8307/greenlet-3.3.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1108b61b06b5224656121c3c8ee8876161c491cbe74e5c519e0634c837cf93d5", size = 597461, upload-time = "2026-01-23T16:15:51.943Z" },
     { url = "https://files.pythonhosted.org/packages/87/eb/8a1ec2da4d55824f160594a75a9d8354a5fe0a300fb1c48e7944265217e1/greenlet-3.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a300354f27dd86bae5fbf7002e6dd2b3255cd372e9242c933faf5e859b703fe", size = 586985, upload-time = "2026-01-23T15:32:47.968Z" },
     { url = "https://files.pythonhosted.org/packages/15/1c/0621dd4321dd8c351372ee8f9308136acb628600658a49be1b7504208738/greenlet-3.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e84b51cbebf9ae573b5fbd15df88887815e3253fc000a7d0ff95170e8f7e9729", size = 1547271, upload-time = "2026-01-23T16:04:18.977Z" },
     { url = "https://files.pythonhosted.org/packages/9d/53/24047f8924c83bea7a59c8678d9571209c6bfe5f4c17c94a78c06024e9f2/greenlet-3.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0093bd1a06d899892427217f0ff2a3c8f306182b8c754336d32e2d587c131b4", size = 1613427, upload-time = "2026-01-23T15:33:44.428Z" },
@@ -866,7 +865,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
     { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
     { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
@@ -875,7 +873,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -884,7 +881,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -893,7 +889,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -902,7 +897,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
@@ -1122,6 +1116,16 @@ wheels = [
 ]
 
 [[package]]
+name = "kozahub-metadata-schema"
+version = "0.0.0.post1.dev0+265814e"
+source = { git = "https://github.com/monarch-initiative/kozahub-metadata-schema?rev=main#265814e60b043a94a5617c503e4c6b8cd584d9bb" }
+dependencies = [
+    { name = "linkml-runtime" },
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+
+[[package]]
 name = "linkml"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1300,6 +1304,8 @@ dependencies = [
     { name = "duckdb" },
     { name = "kghub-downloader" },
     { name = "koza" },
+    { name = "kozahub-metadata-schema" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -1315,6 +1321,8 @@ requires-dist = [
     { name = "duckdb", specifier = ">=0.10.2" },
     { name = "kghub-downloader", specifier = ">=0.4.0" },
     { name = "koza", specifier = ">=2.0.0" },
+    { name = "kozahub-metadata-schema", git = "https://github.com/monarch-initiative/kozahub-metadata-schema?rev=main" },
+    { name = "requests", specifier = ">=2.28.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Pulls in release-metadata wiring from `koza-ingest-template` via `copier update`
- Adds `src/versions.py` with `get_source_versions()` returning upstream source(s) conforming to `kozahub-metadata-schema`'s `ReleaseMetadata`
- Adds `scripts/write_metadata.py` + `just metadata` recipe (template-provided)
- Resolves any incidental template drift in workflows / `pyproject.toml`

## Verification
- `just metadata` produces a valid `output/release-metadata.yaml`
- File validates against `kozahub-metadata-schema`'s `ReleaseMetadata` class
- Aggregated build receipt across all wired ingests via `kozahub-metadata-schema/examples/aggregate_metadata.py`

Companion PRs are landing across ~24 kozahub ingests as part of the release-metadata rollout.